### PR TITLE
Add support for architecture configuration in kickstart-test plugin

### DIFF
--- a/libpermian/exceptions.py
+++ b/libpermian/exceptions.py
@@ -88,3 +88,13 @@ class StructureConversionError(Exception):
     """ Raised when confersion of event structure fails """
     def __init__(self, from_structure, to_structure, reason):
         super().__init__(f"Conversion from '{from_structure.__name__}' to '{to_structure.__name__}' has failed, {reason}")
+
+class UnsupportedConfiguration(Exception):
+    """
+    Raised for test configuration value not supported by workflow.
+    """
+    def __init__(self, configuration, value):
+        msg = f"Configuration '{configuration}: {value}' is not supported"
+        self.configuration = configuration
+        self.value = value
+        super().__init__(msg)

--- a/tests/test_library/kickstart-test/basic/kstest-missing-arch.plan.yaml
+++ b/tests/test_library/kickstart-test/basic/kstest-missing-arch.plan.yaml
@@ -1,0 +1,8 @@
+name: kstests missing arch
+description: The plan to test missing architecture configuration
+point_person: rvykydal@redhat.com
+artifact_type: kstest-missing-arch
+verified_by:
+  test_cases:
+    direct_list:
+      - container-basic

--- a/tests/test_library/kickstart-test/basic/kstest-poc.plan.yaml
+++ b/tests/test_library/kickstart-test/basic/kstest-poc.plan.yaml
@@ -6,3 +6,5 @@ verified_by:
   test_cases:
     direct_list:
       - container-basic
+configurations:
+  - architecture: x86_64

--- a/tests/test_library/kickstart-test/basic/kstest-unsupported-arch.plan.yaml
+++ b/tests/test_library/kickstart-test/basic/kstest-unsupported-arch.plan.yaml
@@ -1,0 +1,11 @@
+name: kstests usnupported arch
+description: The plan to test unsupported architecture configuration
+point_person: rvykydal@redhat.com
+artifact_type: kstest-unsupported-arch
+verified_by:
+  test_cases:
+    direct_list:
+      - container-basic
+configurations:
+  - architecture: x86_64
+  - architecture: unsupported

--- a/tests/test_library/kickstart-test/results_parsing/test_plans/kstest-rp.plan.yaml
+++ b/tests/test_library/kickstart-test/results_parsing/test_plans/kstest-rp.plan.yaml
@@ -13,3 +13,5 @@ verified_by:
       - packages-multilib
       - selinux-permissive
       - services
+configurations:
+  - architecture: x86_64


### PR DESCRIPTION
Currently the workflow is run on local host so we support running only
single architecture (x86_64).