### PR TITLE
Add API to enable plugins to keep own files

### DIFF
--- a/libpermian/workflows/grouped.py
+++ b/libpermian/workflows/grouped.py
@@ -173,6 +173,25 @@ class GroupedWorkflow(threading.Thread, metaclass=abc.ABCMeta):
         for crc in crcList:
             crc.addLog(name, log_path)
 
+    def groupLogData(self, data, name, crcList=None, filename=None):
+        """
+        Write bytes from *data* to file named *name* under crc's log
+        directory.
+
+        *name* and *filename* have the same meaning as in the method
+        CaseRunConfiguration.openLogfile().  *data* is the bytes to
+        write.
+
+        If *crcList* is not provided, all related crcIds are affected.
+
+        File is overwritten if it exists.
+        """
+        if crcList is None:
+            crcList = self.crcList
+        for crc in crcList:
+            with crc.openLogfile(name, mode='wb', autoadd=True, filename=filename) as fo:
+                fo.write(data)
+
     def formatLogMessage(self, message):
         return self.logFormat.format(
             message=message,

--- a/libpermian/workflows/isolated.py
+++ b/libpermian/workflows/isolated.py
@@ -100,5 +100,8 @@ class IsolatedWorkflow(GroupedWorkflow):
     def addLog(self, name, log_path):
         return self.groupAddLog(name, log_path)
 
+    def logData(self, data, name, filename=None):
+        return self.groupLogData(data, name, filename=None)
+
     def log(self, message, name="workflow"):
         return self.groupLog(message, name)


### PR DESCRIPTION
We need plugins to be able to keep their own produced files along with logs.

Currently this requirement exists for Red Hat's internal Beaker-related plugin, where the job XML will be saved.