### PR TITLE
Add silent exceptions to workflow

### DIFF
--- a/libpermian/workflows/grouped.py
+++ b/libpermian/workflows/grouped.py
@@ -16,6 +16,8 @@ class GroupedWorkflow(threading.Thread, metaclass=abc.ABCMeta):
     Workflow instances should not be directly created, use the factory method
     which should handle creation of the workflow instances.
     """
+    silent_exceptions = tuple()
+
     @classmethod
     @abc.abstractmethod
     def factory(cls, testRuns, crcList):
@@ -61,6 +63,9 @@ class GroupedWorkflow(threading.Thread, metaclass=abc.ABCMeta):
         try:
             self.setup()
             self.execute() if not self.dryRun else self.dry_execute()
+        except self.silent_exceptions as e:
+            self.groupLog(f'Workflow raised silent exception: {e}')
+            self.groupReportResult(self.crcList, Result('DNF', 'ERROR', True))
         except Exception as e:
             self.exceptions.append(dump_exception(e, self))
             self.groupReportResult(self.crcList, Result('DNF', 'ERROR', True))

--- a/libpermian/workflows/test_workflows.py
+++ b/libpermian/workflows/test_workflows.py
@@ -1,8 +1,10 @@
 import unittest
 from libpermian.settings import Settings
 from libpermian.workflows.factory import WorkflowFactory
+from libpermian.workflows.grouped import GroupedWorkflow
 from libpermian.workflows.isolated import IsolatedWorkflow
 from libpermian.workflows.builtin import UnknownWorkflow
+from libpermian.result import Result
 from libpermian.caserunconfiguration import CaseRunConfiguration, CaseRunConfigurationsList
 
 class DummyTestCase():
@@ -44,3 +46,48 @@ class TestWorkflowFactory(unittest.TestCase):
         testRuns.settings = Settings({}, {}, [])
         WorkflowFactory._assignWorkflows('unknown', testRuns, testRuns.caseRunConfigurations)
         self.assertIsInstance(caseRunConfiguration.workflow, UnknownWorkflow)
+
+class SilentlyFailingWorkflow(GroupedWorkflow):
+    silent_exceptions = (NotImplementedError,)
+    def __init__(self, testRuns, crcList):
+        super().__init__(testRuns, crcList)
+        self.mocked_log = ''
+    def setup(self):
+        raise NotImplementedError('This is currently not supported')
+    def groupLog(self, text, **kwargs):
+        self.mocked_log += text
+    def execute(self):
+        pass
+    def factory(self):
+        pass
+    def groupDisplayStatus(self):
+        pass
+    def groupTerminate(self):
+        pass
+
+class BrokenWorkflow(SilentlyFailingWorkflow):
+    def setup(self):
+        pass
+    def execute(self):
+        raise ZeroDivisionError('I\'m broken')
+
+class TestWorkflowExceptions(unittest.TestCase):
+    @unittest.mock.patch('libpermian.testruns.TestRuns', autospec=True)
+    def setUp(self, MockTestRuns):
+        self.crc = CaseRunConfiguration(DummyTestCase(), {}, [])
+        self.mock_testrun = MockTestRuns(None, None, None)
+        self.mock_testrun.caseRunConfigurations = CaseRunConfigurationsList([self.crc])
+        self.mock_testrun.event = None
+        self.mock_testrun.settings = Settings({}, {}, [])
+
+    def test_silent_exception(self):
+        workflow = SilentlyFailingWorkflow(self.mock_testrun, [self.crc])
+        workflow.run()
+        self.assertRegex(workflow.mocked_log, 'Workflow raised silent exception: This is currently not supported.')
+        self.assertEqual(workflow.crcList[0].result, Result('DNF', 'ERROR', True))
+
+    def test_exception(self):
+        workflow = BrokenWorkflow(self.mock_testrun, [self.crc])
+        with self.assertRaises(ZeroDivisionError):
+            workflow.run()
+        self.assertEqual(workflow.crcList[0].result, Result('DNF', 'ERROR', True))


### PR DESCRIPTION
Workflow can in special cases fail without creating exception dump