### PR TITLE
kickstart-test: set launcher --scenario argument

### DIFF
--- a/libpermian/plugins/kickstart_test/__init__.py
+++ b/libpermian/plugins/kickstart_test/__init__.py
@@ -348,6 +348,8 @@ class KickstartTestWorkflow(GroupedWorkflow):
 
         command = self.runner_command
 
+        command = command + ['--scenario', self.event.type]
+
         command = command + ['--platform', self.platform]
 
         if self.url_overrides_path:


### PR DESCRIPTION
The argument is used to tag results of the run for further processing.

Related to this update of the launcher: https://github.com/rhinstaller/kickstart-tests/pull/692