### PR TITLE
Add more logging after reporting is done

### DIFF
--- a/libpermian/pipeline/__init__.py
+++ b/libpermian/pipeline/__init__.py
@@ -99,6 +99,7 @@ class Pipeline():
         self._set_return_code(self._waitForWorkflows(), 1)
         LOGGER.debug('Waiting for other threads to finish')
         self._waitForThreads()
+        LOGGER.info('All execution and reporting is done. Performing other post-reporting and shutdown activities.')
         LOGGER.debug('Running pipeline_ended handlers')
         hooks.builtin.pipeline_ended(self)
         LOGGER.debug('Waiting for other (post) threads to finish')

--- a/libpermian/webui/callbacks.py
+++ b/libpermian/webui/callbacks.py
@@ -62,6 +62,8 @@ def render_static(pipeline):
     if not pipeline.settings.get('WebUI', 'create_static_webui'):
         return
 
+    LOGGER.info('Generating static WebUI')
+
     webui_url = pipeline.webUI.baseurl
     webui_path = pipeline.settings.get('WebUI', 'static_webui_dir')
     static_dir = path.join(webui_path, 'static')
@@ -123,4 +125,5 @@ def render_static(pipeline):
 
     doc.htmlSaveFile(index_path)
     doc.free()
+    LOGGER.info('Static WebUI generation is complete')
     hooks.static_WebUI_rendered(pipeline, index_path)


### PR DESCRIPTION
The reason for those is that WebUI sometimes stops responding to HTTP requests
and it's not clear if it's safe (from results reporting point of view) to
terminate the Permian process as it's stuck on the static WebUI generation.