### PR TITLE
[RTT-4363] Use tplib instead of tclib

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN yum-config-manager --enable powertools; \
 
 # fetch other libraries and tools
 WORKDIR /root
-RUN git clone https://github.com/rhinstaller/tclib.git
+RUN git clone https://github.com/rhinstaller/tplib.git
 
 # set up git
 RUN git config --global user.email "nobody@example.com"; \

--- a/doc/usage/testplan-repo.rst
+++ b/doc/usage/testplan-repo.rst
@@ -7,5 +7,5 @@ Organization
 ------------
 
 -----
-tclib
+tplib
 -----

--- a/in_container
+++ b/in_container
@@ -7,4 +7,4 @@ else
     webui_port=$(comm -23 <(seq 49152 65535 | sort) <(ss -Htan | awk '{print $4}' | cut -d':' -f2 | sort -u) | shuf | head -n 1)
 fi
 
-podman run --rm -it --publish 127.0.0.1:${webui_port}:${webui_port} -e 'PIPELINE*' -e PIPELINE_WebUI_listen_port=${webui_port} -v `pwd`:/root/permian:Z -w /root/permian -e PYTHONPATH=/root/tclib permian "$@"
+podman run --rm -it --publish 127.0.0.1:${webui_port}:${webui_port} -e 'PIPELINE*' -e PIPELINE_WebUI_listen_port=${webui_port} -v `pwd`:/root/permian:Z -w /root/permian -e PYTHONPATH=/root/tplib permian "$@"

--- a/libpermian/caserunconfiguration/__init__.py
+++ b/libpermian/caserunconfiguration/__init__.py
@@ -17,7 +17,7 @@ class CaseRunConfiguration():
     handling of the case-run-configuration.
 
     :param testcase: Test case for which the case-run is executed.
-    :type testcase: tclib.structures.testcase.TestCase
+    :type testcase: tplib.structures.testcase.TestCase
     :param configuration: Configuration for which the case-run is executed.
     :type configuration: dict
     :param testplans: List of testplan ids for which the case-run-configuration executed.
@@ -143,7 +143,7 @@ class CaseRunConfiguration():
         If the state None, assign workflow and change state to queued.
 
         :param workflow: Mark this workflow as the one handling this case-run-configuration.
-        :type workflow: tclib.Workflow
+        :type workflow: tplib.Workflow
         :raises ValueError: When a different workflow instance is assigned.
         :return: None
         :rtype: None
@@ -366,9 +366,9 @@ class ConfigurationsList(list):
         If other configurations is empty, empty dict is added
 
         :param testcase: Testcase
-        :type testcase: tclib.TestCase
+        :type testcase: tplib.TestCase
         :param testplan: Testplan
-        :type testplan: tclib.TestPlan
+        :type testplan: tplib.TestPlan
         :return: Configurations
         :rtype: list of dicts
         """

--- a/libpermian/events/__init__.py
+++ b/libpermian/events/__init__.py
@@ -57,7 +57,7 @@ for pipeline execution, the Pipeline would do something similar::
   }'''
   event = EventFactory.make(settings, event_string)
   branch = event.format_branch_spec(branch_format)
-  # pipeline would clone the git repository fetching the branch and proceed with next steps (passing the event along with tclib.Library and settings for the execution)
+  # pipeline would clone the git repository fetching the branch and proceed with next steps (passing the event along with tplib.Library and settings for the execution)
 
 The event can also hold additional structures (like "other" shown above) which
 are python objects created based on the content of the item which would be::

--- a/libpermian/events/base.py
+++ b/libpermian/events/base.py
@@ -40,7 +40,7 @@ class Event():
         """ Generates caseRunConfigurations for testcases in library relevant to this event
 
         :param library: Library
-        :type library: tclib.Library
+        :type library: tplib.Library
         :return: CaseRunConfigurations
         :rtype: CaseRunConfigurationsList
         """
@@ -72,16 +72,16 @@ class Event():
         - testplan execute_on filter
 
         :param library: pipeline library
-        :type library: tclib.Library
+        :type library: tplib.Library
         :return: Filtered testplans
-        :rtype: list of tclib.TestPlan
+        :rtype: list of tplib.TestPlan
         """
         return library.getTestPlansByQuery('event.handles_testplan_artifact_type(tp.artifact_type) and tp.eval_execute_on(event=event)', event=self)
 
     @property
     def additional_testplans_data(self):
         """ Event can provide additional testplans. Returns python
-        dicts, as if they were tclib files read by yaml.safe_load.
+        dicts, as if they were tplib files read by yaml.safe_load.
 
         :return: list of testplan data
         :rtype: tuple
@@ -91,7 +91,7 @@ class Event():
     @property
     def additional_requrements_data(self):
         """ Event can provide additional requrements. Returns python
-        dicts, as if they were tclib files read by yaml.safe_load.
+        dicts, as if they were tplib files read by yaml.safe_load.
 
         :return: list of requrements data
         :rtype: tuple
@@ -101,7 +101,7 @@ class Event():
     @property
     def additional_testcases_data(self):
         """ Event can provide additional testcases. Returns python
-        dicts, as if they were tclib files read by yaml.safe_load.
+        dicts, as if they were tplib files read by yaml.safe_load.
 
         :return: list of testcases data
         :rtype: tuple

--- a/libpermian/events/test_event.py
+++ b/libpermian/events/test_event.py
@@ -2,7 +2,7 @@ import unittest
 from unittest.mock import patch
 from .base import Event
 from ..settings import Settings
-from tclib import library
+from tplib import library
 
 
 class TestCaseRunsConfigurationsMerge(unittest.TestCase):

--- a/libpermian/pipeline/__init__.py
+++ b/libpermian/pipeline/__init__.py
@@ -2,7 +2,7 @@ import copy
 import os
 import threading
 import logging
-from tclib.library import Library
+from tplib.library import Library
 
 from ..settings import Settings
 from ..events.factory import EventFactory
@@ -133,7 +133,7 @@ class Pipeline():
         """
         Clone repository containing testplans, requirements and testcases and
         store them in :py:attr:`library` attribute using
-        :py:class:`tclib.Library`.
+        :py:class:`tplib.Library`.
         """
         try:
             # first try direct specification of path to library

--- a/libpermian/plugins/api/__init__.py
+++ b/libpermian/plugins/api/__init__.py
@@ -2,7 +2,7 @@
 TODO: Add information about possibilities to extend the pipeline. It should be categorized so that one can focus only on the area they want to extend.
 
 The categories should go to individual api subpackages.
-In each category, provide description about which tclib data is handled by the extension (in case of Workflow, ReportSender)
+In each category, provide description about which tplib data is handled by the extension (in case of Workflow, ReportSender)
 
 Workflows:
 

--- a/libpermian/plugins/beaker_tag/__init__.py
+++ b/libpermian/plugins/beaker_tag/__init__.py
@@ -1,4 +1,4 @@
-from tclib.expressions import eval_bool
+from tplib.expressions import eval_bool
 from libpermian.reportsenders.base import BaseReportSender
 from libpermian.plugins import api
 from libpermian.plugins.beaker import xmlrpc_server

--- a/libpermian/plugins/beaker_tag/test.py
+++ b/libpermian/plugins/beaker_tag/test.py
@@ -5,7 +5,7 @@ from libpermian.settings import Settings
 from libpermian.caserunconfiguration import CaseRunConfiguration, CaseRunConfigurationsList
 from libpermian.result import Result
 from libpermian.issueanalyzer.proxy import IssueAnalyzerProxy
-from tclib import library
+from tplib import library
 
 
 class DummyTestCase():

--- a/libpermian/plugins/kickstart_test/test.py
+++ b/libpermian/plugins/kickstart_test/test.py
@@ -11,7 +11,7 @@ from libpermian.exceptions import UnsupportedConfiguration
 from libpermian.plugins.kickstart_test import SUPPORTED_ARCHITECTURES, \
     KstestParamsStructure, MissingBootIso, MissingInformation, KickstartTestWorkflow
 
-from tclib.library import Library
+from tplib.library import Library
 
 DUMMY_BOOT_ISO_URL = "file:///tmp/boot.iso"
 

--- a/libpermian/plugins/run_subset/__init__.py
+++ b/libpermian/plugins/run_subset/__init__.py
@@ -1,7 +1,7 @@
 import json
 import argparse
 
-from tclib.expressions import eval_bool
+from tplib.expressions import eval_bool
 
 from .. import api
 from ...cli.factory import CliFactory

--- a/libpermian/plugins/run_subset/test.py
+++ b/libpermian/plugins/run_subset/test.py
@@ -2,7 +2,7 @@ import json
 import unittest
 from unittest.mock import patch, create_autospec, MagicMock
 
-from tclib.library import Library
+from tplib.library import Library
 
 from libpermian.caserunconfiguration import CaseRunConfigurationsList
 from libpermian.cli.factory import CliFactory

--- a/libpermian/reportsenders/base.py
+++ b/libpermian/reportsenders/base.py
@@ -23,9 +23,9 @@ class BaseReportSender(threading.Thread, metaclass=abc.ABCMeta):
     deliver the desired reporting.
 
     :param testplan: TestPlan instance for which the reporting should be done.
-    :type testplan: tclib.structures.testplan.TestPlan
+    :type testplan: tplib.structures.testplan.TestPlan
     :param reporting_structure: Test Plan reporting item containing data for this instance.
-    :type reporting_structure: tclib.structures.testplan.Reporting
+    :type reporting_structure: tplib.structures.testplan.Reporting
     :param caseRunConfigurations: List of case-run-configurations for which the reports should be sent.
     :type caseRunConfigurations: list[:class:`libpermian.testrun.CaseRunConfiguration`]
     :param event: Event based on which the reporting should be done. The ReportSender may use this to obtain more information useful for reporting.

--- a/libpermian/reportsenders/factory.py
+++ b/libpermian/reportsenders/factory.py
@@ -1,6 +1,6 @@
 import yaml
 from os import path
-from tclib.structures.testplan import Reporting
+from tplib.structures.testplan import Reporting
 
 
 class ReportSenderFactory():
@@ -71,8 +71,8 @@ class ReportSenderFactory():
         :param additional_file: path to file with additional reporters
         :type additional_file: string
         :param library: test data library
-        :type library: tclib.Library
-        :return: list of tclib.testplan.Reporting objects
+        :type library: tplib.Library
+        :return: list of tplib.testplan.Reporting objects
         :rtype: list
         """
         if additional_file == '':

--- a/libpermian/reportsenders/test_reportsenders.py
+++ b/libpermian/reportsenders/test_reportsenders.py
@@ -1,5 +1,5 @@
 import unittest
-from tclib import library
+from tplib import library
 from libpermian.settings import Settings
 from libpermian.reportsenders.factory import ReportSenderFactory
 from libpermian.testruns import TestRuns

--- a/libpermian/testruns/__init__.py
+++ b/libpermian/testruns/__init__.py
@@ -10,7 +10,7 @@ from ..result import Result
 LOGGER = logging.getLogger(__name__)
 
 class TestRuns():
-    """Collection of case-run-configurations based on the Test Plans, Requirements and Test Cases from tclib provided library.
+    """Collection of case-run-configurations based on the Test Plans, Requirements and Test Cases from tplib provided library.
 
     This class also handles assignment of the workflows and manages their
     execution.

--- a/libpermian/testruns/test_testruns.py
+++ b/libpermian/testruns/test_testruns.py
@@ -1,5 +1,5 @@
 import unittest
-from tclib import library
+from tplib import library
 from libpermian.settings import Settings
 from libpermian.events.base import Event
 from libpermian.workflows.factory import WorkflowFactory

--- a/libpermian/webui/test_webui.py
+++ b/libpermian/webui/test_webui.py
@@ -5,7 +5,7 @@ import urllib.request
 import requests
 import tempfile
 from flask import Blueprint
-from tclib import library
+from tplib import library
 from .server import WebUI
 from ..events.base import Event
 from ..settings import Settings


### PR DESCRIPTION
That's because tclib has been renamed to tplib.