### PR TITLE
Implement throttled reporting to github-pr reportSender

### DIFF
--- a/libpermian/plugins/github/__init__.py
+++ b/libpermian/plugins/github/__init__.py
@@ -131,7 +131,7 @@ class GitHubPullRequestReportSender(BaseReportSender):
             raise GitHubReportingException(cru_response.status_code, cru_response.text)
 
     def processPartialResult(self, crc):
-        pass
+        self.send_update(self.make_payload())
 
     def processFinalResult(self, crc):
         self.send_update(self.make_payload())
@@ -155,4 +155,8 @@ class GitHubPullRequestReportSender(BaseReportSender):
         self.send_update(self.make_payload('completed', conclusion))
 
     def processCaseRunFinished(self, testCaseID):
-        pass
+        self.send_update(self.make_payload())
+
+    def flush(self):
+        self.send_update(self.make_payload())
+        return True

--- a/libpermian/plugins/github/settings.ini
+++ b/libpermian/plugins/github/settings.ini
@@ -7,3 +7,7 @@ repository =
 token = 
 # Pull request id - this should be only set as settings override
 pull-request = 
+
+[reportSender-github-pr]
+# by default report results only once a minute
+throttleInterval = 60


### PR DESCRIPTION
I also enabled it by default because non enterprise projects
on GitHub are limited to 1000 requests per hour, which isn't
that much now that we send update on every status change.