### PR TITLE
Do not guess log filenames when rendering static webui

### DIFF
--- a/libpermian/webui/builtin.py
+++ b/libpermian/webui/builtin.py
@@ -1,5 +1,6 @@
 import logging
 import magic
+import mimetypes
 from flask import Blueprint, render_template, jsonify, request, redirect, Response
 
 from ..exceptions import RemoteLogError
@@ -60,7 +61,8 @@ def logs(crcid, name):
     try:
         with pipeline.testRuns.caseRunConfigurations[crcid].openLogfile(name, mode='rb') as logfile:
             data = logfile.read()
-            return Response(data, mimetype=magic.detect_from_content(data).mime_type)
+            mimetype = mimetypes.guess_type(logfile.name)[0] or magic.detect_from_content(data).mime_type
+            return Response(data, mimetype=mimetype)
     except RemoteLogError as e:
         return redirect(e.log_path)
 


### PR DESCRIPTION
The previous implementation assumed a filename pattern of the logs as well as the location of the logs. Instead, just download the logs one by one storing them in a separate directory to ensure that the resulting links are correct and that all the log files are properly stored.