### PR TITLE
[RTT-4886] Update documentation location

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,8 @@ Execute all or just part of the tests
 ```
 ./in_container make doc
 ```
+
+Documentation
+-------------
+The rendered documentation is located at http://permian.readthedocs.io.
+


### PR DESCRIPTION
The documentation is now located on Read The Docs.