### PR TITLE
Add support for z-stream and other product subversions

### DIFF
--- a/libpermian/default.ini
+++ b/libpermian/default.ini
@@ -22,7 +22,7 @@ branchNameStrategy=drop-least-significant
 # branchNameStrategy either branch of this format (or modified) will be used.
 # Jinja2 template is used for branch name formatting where the event as well as
 # all event structures are provided as separate variables.
-branchNameFormat={{event.product.name.lower()}}-{{event.product.major}}.{{event.product.minor}}
+branchNameFormat={{event.product.name.lower()}}-{{event.product.major}}.{{event.product.minor}}.{{event.product.other}}.{{event.product.flag}}
 # Determines how test configurations of testplan and testcase are merged
 # Possible methods are:
 #   intersection - include the CaseRunConfiguration in TestRun only if the configurations in testplan and testcase are identical

--- a/libpermian/events/structures/builtin.py
+++ b/libpermian/events/structures/builtin.py
@@ -3,11 +3,13 @@ from .base import BaseStructure
 
 @EventStructuresFactory.register('product')
 class ProductStructure(BaseStructure):
-    def __init__(self, settings, name, major, minor):
+    def __init__(self, settings, name, major, minor, other=None, flag=None):
         super().__init__(settings)
         self.name = name
         self.major = major
         self.minor = minor
+        self.other = other
+        self.flag = flag
 
 @EventStructuresFactory.register('other')
 class OtherStructure(BaseStructure):

--- a/libpermian/plugins/compose/__init__.py
+++ b/libpermian/plugins/compose/__init__.py
@@ -171,6 +171,8 @@ class ComposeStructure(BaseStructure):
             self.product,
             self.major,
             self.minor,
+            self.qr,
+            None, # no support for product flag yet
         )
 
     def to_bootIso(self):

--- a/libpermian/plugins/koji/__init__.py
+++ b/libpermian/plugins/koji/__init__.py
@@ -19,7 +19,7 @@ from libpermian.plugins.beaker import BeakerCompose
 
 TAG_REGEXPS = (
     # product-1.2.3-state
-    re.compile('(?P<product>[^-]+)-(?P<major>[0-9]+).(?P<minor>[0-9]+).(?P<qr>[0-9]+)-(?P<state>[^-]+)'),
+    re.compile('(?P<product>[^-]+)-(?P<major>[0-9]+).(?P<minor>[0-9]+).(?P<qr>[0-9]+)-((?P<flag>.+)-)?(?P<state>[^-]+)'),
 )
 
 def parse_koji_tag(tag):
@@ -31,6 +31,8 @@ def parse_koji_tag(tag):
             'product' : mo.group('product'),
             'major' : mo.group('major'),
             'minor' : mo.group('minor'),
+            'qr' : mo.group('qr'),
+            'flag' : mo.group('flag'),
         }
     return None
 
@@ -115,6 +117,8 @@ class KojiBuild(BaseStructure):
             parsed_tag['product'],
             parsed_tag['major'],
             parsed_tag['minor'],
+            parsed_tag['qr'],
+            parsed_tag['flag'],
         )
 
 @api.events.register('koji')

--- a/libpermian/plugins/koji/test.py
+++ b/libpermian/plugins/koji/test.py
@@ -204,3 +204,39 @@ class TestKojiEventStructure(unittest.TestCase):
             call(entrypoint)
         ])
         self.assertEqual(requests_get.call_count, 3)
+
+    def test_convert_product_base(self, tag):
+        expected_mapping = {
+            'foo-1.2.3-bar' : {
+                'name' : 'foo',
+                'major' : '1',
+                'minor' : '2',
+                'other' : '3',
+                'flag' : None,
+            },
+            'Woody-0.4.2-damaged-lost' : {
+                'name' : 'Woody',
+                'major' : '0',
+                'minor' : '4',
+                'other' : '2',
+                'flag' : 'damaged',
+            },
+            'acme-1956.5.5-Gee-Whiz-z-z-z-z-z-z' : {
+                'name' : 'acme',
+                'major' : '1956',
+                'minor' : '5',
+                'other' : '5',
+                'flag' : 'Gee-Whiz-z-z-z-z-z',
+            },
+        }
+        for tag, expected_product_attrs in expected_mapping.items():
+            with self.subTest(tag=tag):
+                koji_build = KojiBuild(
+                    self.settings,
+                    self.nvr, build_id=self.build_id,
+                    task_id=self.task_id, package_name=self.package_name,
+                    new_tag=tag,
+                )
+                product = koji_build.to_product()
+                for attr, expected_value in expected_product_attrs.items():
+                    self.assertEqual(getattr(product, attr), expected_value)


### PR DESCRIPTION
This is also useful for ad-hoc branches like for specific set of fixes that are tested before they are merged to a mainline branch.