### PR TITLE
Use greener color for PASSed results

### DIFF
--- a/libpermian/webui/static/style.css
+++ b/libpermian/webui/static/style.css
@@ -98,7 +98,7 @@ h1 {
 
 /* result conditional formating */
 .crc_result[data-result="PASS"] {
-    background-color: rgba(0, 255, 0, 0.25);
+    background-color: rgba(0, 128, 0, 0.25);
 }
 .crc_result[data-result="FAIL"] {
     background-color: rgba(255, 0, 0, 0.25);


### PR DESCRIPTION
It makes it easier to distinguish PASS and ERROR results.