### PR TITLE
Include local_logs directory in the make clean command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,4 +11,4 @@ test.integration:
 doc:
 	make -C doc html
 clean:
-	rm -r *.log *.dump logs xunit-*.xml index.html pipeline_data static || :
+	rm -r *.log *.dump logs local_logs xunit-*.xml index.html pipeline_data static || :


### PR DESCRIPTION
New directory for storing log files was introduced in commit 560af807f28d3a1999c1779894b2fd102b7e41ac, but we forgot about the cleanup