### PR TITLE
Use newer version of cockpit for Anaconda WebUI testing

### DIFF
--- a/libpermian/plugins/anaconda_webui/settings.ini
+++ b/libpermian/plugins/anaconda_webui/settings.ini
@@ -2,7 +2,7 @@
 # Anaconda repo, use file:// to copy local directory or anything else to clone git repo
 anaconda_repo=https://github.com/rhinstaller/anaconda.git
 cockpit_repo=https://github.com/cockpit-project/cockpit.git
-cockpit_branch=283
+cockpit_branch=289
 bots_repo=https://github.com/cockpit-project/bots.git
 bots_branch=main
 hypervisor_vm_limit=2


### PR DESCRIPTION
After some changes in the Anaconda repo the old version no longer works.