### PR TITLE
Add support for composes in form PROD-maj.min[.qr]

### DIFF
--- a/libpermian/plugins/compose/__init__.py
+++ b/libpermian/plugins/compose/__init__.py
@@ -31,7 +31,7 @@ class ComposeEvent(Event):
 
 @api.events.register_structure('compose')
 class ComposeStructure(BaseStructure):
-    id_regex = re.compile(r'(?P<product>\w+)-(?P<version>(?P<major>\d+)(\.(?P<minor>\d+))?(\.(?P<qr>\d))?)(-updates)?(-(?P<parent>\w+)-\d)?-(?P<date>\d+)(\.(?P<flag>.))?\.(?P<spin>\d+)')
+    id_regex = re.compile(r'(?P<product>\w+)-(?P<version>(?P<major>\d+)(\.(?P<minor>\d+))?(\.(?P<qr>\d))?)((-updates)?(-(?P<parent>\w+)-\d)?-(?P<date>\d+)(\.(?P<flag>.))?\.(?P<spin>\d+))?')
 
     def __init__(self, settings, id, product=None, version=None, major=None, minor=None, qr=None, date=None, respin=None, location=None, location_http=None, compose_type=None, nightly=None, development=None, label=None, prerelease=None, tags=None, new_tag=None, layered=None, parent_product=None, parent_version=None, available_in=None):
         super().__init__(settings)
@@ -100,6 +100,11 @@ class ComposeStructure(BaseStructure):
             # there's no simple way to implement this, the information about
             # prerelase needs to be passed from external source when label is
             # missing.
+            return False
+        if not self.development \
+           and not self.nightly \
+           and self.date is None \
+           and self.spin is None:
             return False
         return not self.label.startswith('RC-')
 

--- a/libpermian/plugins/compose/test_compose.py
+++ b/libpermian/plugins/compose/test_compose.py
@@ -135,6 +135,40 @@ class TestEventCompose(unittest.TestCase):
         self.assertTrue(event.compose.layered)
         self.assertEqual(event.compose.location, 'http://example.com/here/Supp-9.2.1-updates-RHEL-8-20200811.5')
 
+    def test_released_rhel_id_only(self):
+        event = EventFactory.make(self.settings, CliFactory.parse('compose', ['RHEL-9.4.0'])[1])
+        self.assertEqual(event.compose.id, 'RHEL-9.4.0')
+        self.assertEqual(event.compose.version, '9.4.0')
+        self.assertEqual(event.compose.major, '9')
+        self.assertEqual(event.compose.minor, '4')
+        self.assertEqual(event.compose.qr, '0')
+        self.assertEqual(event.compose.spin, None)
+        self.assertEqual(event.compose.date, None)
+        self.assertEqual(event.compose.product, 'RHEL')
+        self.assertIsNone(event.compose.parent_product)
+        self.assertIsNone(event.compose.parent_version)
+        self.assertFalse(event.compose.nightly)
+        self.assertFalse(event.compose.prerelease)
+        self.assertFalse(event.compose.layered)
+        self.assertEqual(event.compose.location, 'http://example.com/here/RHEL-9.4.0')
+
+    def test_released_rhel_short_id_only(self):
+        event = EventFactory.make(self.settings, CliFactory.parse('compose', ['RHEL-10.0'])[1])
+        self.assertEqual(event.compose.id, 'RHEL-10.0')
+        self.assertEqual(event.compose.version, '10.0')
+        self.assertEqual(event.compose.major, '10')
+        self.assertEqual(event.compose.minor, '0')
+        self.assertEqual(event.compose.qr, None)
+        self.assertEqual(event.compose.spin, None)
+        self.assertEqual(event.compose.date, None)
+        self.assertEqual(event.compose.product, 'RHEL')
+        self.assertIsNone(event.compose.parent_product)
+        self.assertIsNone(event.compose.parent_version)
+        self.assertFalse(event.compose.nightly)
+        self.assertFalse(event.compose.prerelease)
+        self.assertFalse(event.compose.layered)
+        self.assertEqual(event.compose.location, 'http://example.com/here/RHEL-10.0')
+
     def test_rhel_overrides(self):
         event = EventFactory.make(self.settings,
                                   CliFactory.parse('compose', ['RHEL-8.3.0-20200701.2',


### PR DESCRIPTION
Already released composes are available in a short form i.e. RHEL-9.4.0
Composetree can handle it and provides correct URL/redirection so it should be allowed in permian's events as well.