### PR TITLE
Set artifacts_links in final results in testing farm workflow

### DIFF
--- a/libpermian/plugins/testing_farm/__init__.py
+++ b/libpermian/plugins/testing_farm/__init__.py
@@ -159,7 +159,7 @@ class TestingFarmWorkflow(IsolatedWorkflow):
                     if status['result']['overall'] in result2result_map:
                         self.reportResult(Result('complete',
                                                 result2result_map[status['result']['overall']],
-                                                final=True))
+                                                final=True, artifacts_links=[self.weblink] if self.weblink else []))
                         break
                     else:
                         self.reportResult(Result('complete', 'ERROR', final=True))
@@ -168,7 +168,7 @@ class TestingFarmWorkflow(IsolatedWorkflow):
                 elif state in ['error', 'canceled']:
                     self.reportResult(Result(state2state_map[state],
                                             state2result_map[state],
-                                            final=True))
+                                            final=True, artifacts_links=[self.weblink] if self.weblink else []))
                     break
 
                 elif state in state2state_map and self.crc.result.state != state2state_map[state]:

--- a/libpermian/reportsenders/base.py
+++ b/libpermian/reportsenders/base.py
@@ -34,7 +34,7 @@ class BaseReportSender(threading.Thread, metaclass=abc.ABCMeta):
     :param settings: Pipeline settings object
     :type settings: libpermian.settings.Settings
     """
-    description_format = "Configuration: %s - Result: %s, %s - Beaker links: %s - Issues: %s ; "
+    description_format = "Configuration: %s - Result: %s, %s - Artifacts links: %s - Issues: %s ; "
     issue_format = "%s"
     def __init__(self, testplan, reporting_structure, caseRunConfigurations, event, settings, issueAnalyzerProxy, group=None):
         super().__init__()
@@ -244,7 +244,7 @@ class BaseReportSender(threading.Thread, metaclass=abc.ABCMeta):
                     ', '.join([
                         link
                         for link
-                        in crc.result.extra_fields.get('beaker_links', ['None'])
+                        in crc.result.extra_fields.get('artifacts_links', ['None'])
                     ]),
                     '\n'.join([
                         self.issue_format % issue

--- a/tests/integration/test_xunit/test_0_result/xunit-xunit testplan 1.xml
+++ b/tests/integration/test_xunit/test_0_result/xunit-xunit testplan 1.xml
@@ -7,17 +7,17 @@
             <properties>
             </properties>
             <system-out>
-            Configuration: {&#39;conf&#39;: 1} - Result: DNF, None - Beaker links: None - Issues:  ; Configuration: {&#39;conf&#39;: 2} - Result: DNF, None - Beaker links: None - Issues:  ; 
+            Configuration: {&#39;conf&#39;: 1} - Result: DNF, None - Artifacts links: None - Issues:  ; Configuration: {&#39;conf&#39;: 2} - Result: DNF, None - Artifacts links: None - Issues:  ; 
             </system-out>
-            <skipped message="Configuration: {&#39;conf&#39;: 1} - Result: DNF, None - Beaker links: None - Issues:  ; Configuration: {&#39;conf&#39;: 2} - Result: DNF, None - Beaker links: None - Issues:  ; " type="skipped" />
+            <skipped message="Configuration: {&#39;conf&#39;: 1} - Result: DNF, None - Artifacts links: None - Issues:  ; Configuration: {&#39;conf&#39;: 2} - Result: DNF, None - Artifacts links: None - Issues:  ; " type="skipped" />
         </testcase>
         <testcase name="testing plugin case 1" classname="xunit testplan 1">
             <properties>
             </properties>
             <system-out>
-            Configuration: {&#39;conf&#39;: 1, &#39;initial_delay&#39;: 0.1} - Result: complete, FAIL - Beaker links: None - Issues:  ; Configuration: {&#39;conf&#39;: 2, &#39;initial_delay&#39;: 0.1} - Result: complete, FAIL - Beaker links: None - Issues:  ; 
+            Configuration: {&#39;conf&#39;: 1, &#39;initial_delay&#39;: 0.1} - Result: complete, FAIL - Artifacts links: None - Issues:  ; Configuration: {&#39;conf&#39;: 2, &#39;initial_delay&#39;: 0.1} - Result: complete, FAIL - Artifacts links: None - Issues:  ; 
             </system-out>
-            <error message="Configuration: {&#39;conf&#39;: 1, &#39;initial_delay&#39;: 0.1} - Result: complete, FAIL - Beaker links: None - Issues:  ; Configuration: {&#39;conf&#39;: 2, &#39;initial_delay&#39;: 0.1} - Result: complete, FAIL - Beaker links: None - Issues:  ; " type="error" />
+            <error message="Configuration: {&#39;conf&#39;: 1, &#39;initial_delay&#39;: 0.1} - Result: complete, FAIL - Artifacts links: None - Issues:  ; Configuration: {&#39;conf&#39;: 2, &#39;initial_delay&#39;: 0.1} - Result: complete, FAIL - Artifacts links: None - Issues:  ; " type="error" />
         </testcase>
     </testsuite>
 </testsuites>

--- a/tests/integration/test_xunit/test_1_result/xunit-xunit grouped testplan-variant:test;initial_delay:0.2.xml
+++ b/tests/integration/test_xunit/test_1_result/xunit-xunit grouped testplan-variant:test;initial_delay:0.2.xml
@@ -7,7 +7,7 @@
             <properties>
             </properties>
             <system-out>
-            Configuration: {&#39;conf&#39;: 1, &#39;initial_delay&#39;: 0.2, &#39;variant&#39;: &#39;test&#39;} - Result: complete, PASS - Beaker links: None - Issues:  ; Configuration: {&#39;conf&#39;: 2, &#39;initial_delay&#39;: 0.2, &#39;variant&#39;: &#39;test&#39;} - Result: complete, PASS - Beaker links: None - Issues:  ; 
+            Configuration: {&#39;conf&#39;: 1, &#39;initial_delay&#39;: 0.2, &#39;variant&#39;: &#39;test&#39;} - Result: complete, PASS - Artifacts links: None - Issues:  ; Configuration: {&#39;conf&#39;: 2, &#39;initial_delay&#39;: 0.2, &#39;variant&#39;: &#39;test&#39;} - Result: complete, PASS - Artifacts links: None - Issues:  ; 
             </system-out>
         </testcase>
     </testsuite>

--- a/tests/integration/test_xunit/test_1_result/xunit-xunit grouped testplan-variant:test;initial_delay:0.5.xml
+++ b/tests/integration/test_xunit/test_1_result/xunit-xunit grouped testplan-variant:test;initial_delay:0.5.xml
@@ -7,9 +7,9 @@
             <properties>
             </properties>
             <system-out>
-            Configuration: {&#39;conf&#39;: 1, &#39;initial_delay&#39;: 0.5, &#39;variant&#39;: &#39;test&#39;} - Result: complete, FAIL - Beaker links: None - Issues:  ; Configuration: {&#39;conf&#39;: 2, &#39;initial_delay&#39;: 0.5, &#39;variant&#39;: &#39;test&#39;} - Result: complete, FAIL - Beaker links: None - Issues:  ; 
+            Configuration: {&#39;conf&#39;: 1, &#39;initial_delay&#39;: 0.5, &#39;variant&#39;: &#39;test&#39;} - Result: complete, FAIL - Artifacts links: None - Issues:  ; Configuration: {&#39;conf&#39;: 2, &#39;initial_delay&#39;: 0.5, &#39;variant&#39;: &#39;test&#39;} - Result: complete, FAIL - Artifacts links: None - Issues:  ; 
             </system-out>
-            <error message="Configuration: {&#39;conf&#39;: 1, &#39;initial_delay&#39;: 0.5, &#39;variant&#39;: &#39;test&#39;} - Result: complete, FAIL - Beaker links: None - Issues:  ; Configuration: {&#39;conf&#39;: 2, &#39;initial_delay&#39;: 0.5, &#39;variant&#39;: &#39;test&#39;} - Result: complete, FAIL - Beaker links: None - Issues:  ; " type="error" />
+            <error message="Configuration: {&#39;conf&#39;: 1, &#39;initial_delay&#39;: 0.5, &#39;variant&#39;: &#39;test&#39;} - Result: complete, FAIL - Artifacts links: None - Issues:  ; Configuration: {&#39;conf&#39;: 2, &#39;initial_delay&#39;: 0.5, &#39;variant&#39;: &#39;test&#39;} - Result: complete, FAIL - Artifacts links: None - Issues:  ; " type="error" />
         </testcase>
     </testsuite>
 </testsuites>


### PR DESCRIPTION
This fixes missing links in Polarion reporting.